### PR TITLE
Make dropdown translatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/.flatpak-builder
-/builddir
-/repo
+.flatpak-builder
+builddir
+build-dir
+repo

--- a/src/gresources/io.github.josephmawa.Bella.src.gresource.xml
+++ b/src/gresources/io.github.josephmawa.Bella.src.gresource.xml
@@ -13,5 +13,6 @@
     <file>utils/saved-color.js</file>
     <file>utils/color-names.js</file>
     <file>utils/nearest-color.js</file>
+    <file>utils/color-formats.js</file>
   </gresource>
 </gresources>

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -1,8 +1,9 @@
 import Adw from "gi://Adw";
 import GObject from "gi://GObject";
 import Gio from "gi://Gio";
+import Gtk from "gi://Gtk";
 import { ConfirmDeleteAll } from "./confirm-delete-all.js";
-import { colorFormats } from "./utils/utils.js";
+import { colorFormats } from "./utils/color-formats.js";
 
 export const BellaPreferencesDialog = GObject.registerClass(
   {
@@ -29,6 +30,8 @@ export const BellaPreferencesDialog = GObject.registerClass(
   class BellaPreferencesDialog extends Adw.PreferencesDialog {
     constructor(options = {}) {
       super(options);
+
+      this.setColorFormatModel();
 
       this.settings = Gio.Settings.new("io.github.josephmawa.Bella");
       this.settings.bind(
@@ -126,5 +129,10 @@ export const BellaPreferencesDialog = GObject.registerClass(
       const confirmDeleteAll = new ConfirmDeleteAll();
       confirmDeleteAll.present(this);
     }
+
+    setColorFormatModel = () => {
+      const _colorFormats = colorFormats.map(({ description }) => description);
+      this._colorFormatSettings.model = Gtk.StringList.new(_colorFormats);
+    };
   }
 );

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -111,18 +111,6 @@
               <object class="AdwComboRow" id="colorFormatSettings">
                 <property name="title" translatable="yes">Color Format</property>
                 <property name="subtitle" translatable="yes">Select color format to display</property>
-                <property name="model">
-                  <object class="GtkStringList">
-                    <items>
-                      <item>Name</item>
-                      <item>Hex</item>
-                      <item>RGB</item>
-                      <item>RGB Percent</item>
-                      <item>HSL</item>
-                      <item>HSV</item>
-                    </items>
-                  </object>
-                </property>
               </object>
             </child>
           </object>

--- a/src/utils/color-formats.js
+++ b/src/utils/color-formats.js
@@ -1,0 +1,32 @@
+export const colorFormats = [
+  {
+    key: "name",
+    // Color name
+    description: _("Name"),
+  },
+  {
+    key: "hex",
+    // Hexadecimal color format
+    description: _("Hex"),
+  },
+  {
+    key: "rgb",
+    // RGB color format
+    description: _("RGB"),
+  },
+  {
+    key: "rgb_percent",
+    // RGB Percent color format
+    description: _("RGB Percent"),
+  },
+  {
+    key: "hsl",
+    // HSL color format
+    description: _("HSL"),
+  },
+  {
+    key: "hsv",
+    // HSV color format
+    description: _("HSV"),
+  },
+];

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -72,13 +72,3 @@ export function round(number, decimalPlaces = 0) {
   const multiple = Math.pow(10, decimalPlaces);
   return Math.round(number * multiple) / multiple;
 }
-
-
-export const colorFormats = [
-  { key: "name", description: "Name" },
-  { key: "hex", description: "Hex" },
-  { key: "rgb", description: "RGB" },
-  { key: "rgb_percent", description: "RGB Percent" },
-  { key: "hsl", description: "HSL" },
-  { key: "hsv", description: "HSV" },
-];

--- a/src/window.js
+++ b/src/window.js
@@ -6,7 +6,8 @@ import Gio from "gi://Gio";
 import Xdp from "gi://Xdp";
 import GLib from "gi://GLib";
 
-import { getColor, getHsv, colorFormats } from "./utils/utils.js";
+import { getColor, getHsv } from "./utils/utils.js";
+import { colorFormats } from "./utils/color-formats.js";
 import { SavedColor } from "./utils/saved-color.js";
 import { BellaPreferencesDialog } from "./preferences.js";
 import { savedColorsFile } from "./application.js";


### PR DESCRIPTION
This PR will make the dropdown translatable. Currently, translating the hard-corded color formats in the `preferences.ui` definition file will break the app.